### PR TITLE
Symlink python to python3 in Bazel image.

### DIFF
--- a/bazel/BUILD.bazel
+++ b/bazel/BUILD.bazel
@@ -63,6 +63,7 @@ container_image(
     stamp = True,
     symlinks = {
         "/usr/bin/clang": "/usr/bin/clang-10",
+        "/usr/bin/python": "/usr/bin/python3",
     },
 )
 


### PR DESCRIPTION
This is similar to the effect of the python-is-python3 convenience package offered in newer versions of Ubuntu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/containers/3)
<!-- Reviewable:end -->
